### PR TITLE
Removing fix and quiet options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,5 @@
 # vim: set syntax=yaml:
 ---
-  fix: true
-  quiet: true
   env:
     node: true
   rules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "@retailmenot/core-ui-eslintrc",
+  "version": "5.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@retailmenot/core-ui-editorconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@retailmenot/core-ui-editorconfig/-/core-ui-editorconfig-1.0.2.tgz",
+      "integrity": "sha1-ecnzQYkxoyltu3Qu7VpWCCA92f4=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
   },
   "contributors": [
     "Eric Capps <ecapps@rmn.com>",
-    "Lon Ingram <lingram@rmn.com>"
+    "Lon Ingram <lingram@rmn.com>",
+    "Ray Pierce <ray@digitalpierce.com>"
   ],
   "license": "MIT",
   "devDependencies": {
     "@retailmenot/core-ui-editorconfig": "^1.0.2"
   },
   "peerDependencies": {
-    "eslint": "^3.7.1"
+    "eslint": "^4.7.2"
   }
 }


### PR DESCRIPTION
* The fix and quiet options throw "Unexpected top-level property" errors in eslint 4.x
* Updated peerDependency to 4.7.2 as that is the current version
* Added a package-lock.json generated from npm 5.4.2